### PR TITLE
Fixed duplicate Media objects in chat

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -57,10 +57,10 @@ class Api {
         }
 
         if (message.message) {
-          EventEmitter.emit("onMessage", message.message);
           if (this.onMessageListener) {
             this.onMessageListener(message.message);
           }
+          EventEmitter.emit("onMessage", message.message);
           return;
         }
 

--- a/src/components/screens/chat/ChatForm.js
+++ b/src/components/screens/chat/ChatForm.js
@@ -231,6 +231,7 @@ export default function ChatForm({
 
     setIsSendMessageDisable(false);
     scrollChatToBottom();
+    messageInputEl.current.focus();
   };
 
   const deleteChat = async () => {

--- a/src/components/screens/chat/MessagesList.js
+++ b/src/components/screens/chat/MessagesList.js
@@ -44,15 +44,17 @@ export default function MessagesList({ scrollRef, openModalFunc }) {
         }
 
         const messagesIds = arr.map((el) => el._id).reverse();
-        needToGetMoreMessage.current =
-          messagesIds.length <=
-          +process.env.REACT_APP_MESSAGES_COUNT_TO_PRELOAD;
+        needToGetMoreMessage.current = !(
+          messagesIds.length < +process.env.REACT_APP_MESSAGES_COUNT_TO_PRELOAD
+        );
 
         dispatch(addMessages(arr));
         dispatch(
           upsertChat({
             _id: selectedCID,
-            messagesIds: [...messagesIds, ...messages.map((el) => el._id)],
+            messagesIds: [
+              ...new Set([...messagesIds, ...messages.map((el) => el._id)]),
+            ],
             activated: true,
           })
         );

--- a/src/services/notifications.js
+++ b/src/services/notifications.js
@@ -20,18 +20,26 @@ async function showLocalNotification(pushMessage) {
     return;
   }
 
-  const notificationMessage = { ...pushMessage };
-  const userLogin = storeState.participants.entities[pushMessage.from]?.login;
-  if (pushMessage.attachments?.length) {
-    notificationMessage["body"] =
-      pushMessage.body + pushMessage.attachments.length > 1
-        ? `\nPhotos`
-        : `\nPhoto`;
-  }
-  notificationMessage["title"] =
+  const { attachments, from, body } = pushMessage;
+  const userLogin = storeState.participants.entities[from]?.login;
+
+  const attachmentText =
+    attachments?.length > 0
+      ? attachments.length > 1
+        ? "\nPhotos"
+        : "\nPhoto"
+      : "";
+
+  const title =
     conversation.type === "u"
       ? userLogin
       : `${userLogin} | ${conversation.name}`;
+
+  const notificationMessage = {
+    ...pushMessage,
+    body: `${body}${attachmentText}`,
+    title,
+  };
   sw.postMessage({ message: notificationMessage });
 }
 EventEmitter.subscribe("onMessage", showLocalNotification);

--- a/src/services/notifications.js
+++ b/src/services/notifications.js
@@ -19,16 +19,20 @@ async function showLocalNotification(pushMessage) {
     //TODO: need to sync with server | conversation_lsit
     return;
   }
+
+  const notificationMessage = { ...pushMessage };
   const userLogin = storeState.participants.entities[pushMessage.from]?.login;
   if (pushMessage.attachments?.length) {
-    pushMessage["body"] += `\nPhoto`;
+    notificationMessage["body"] =
+      pushMessage.body + pushMessage.attachments.length > 1
+        ? `\nPhotos`
+        : `\nPhoto`;
   }
-  pushMessage["title"] =
+  notificationMessage["title"] =
     conversation.type === "u"
       ? userLogin
       : `${userLogin} | ${conversation.name}`;
-
-  sw.postMessage({ message: pushMessage });
+  sw.postMessage({ message: notificationMessage });
 }
 EventEmitter.subscribe("onMessage", showLocalNotification);
 

--- a/src/store/Messages.js
+++ b/src/store/Messages.js
@@ -32,7 +32,6 @@ export const messages = createSlice({
         .map((id) => {
           return { _id: id, status: "read" };
         });
-      console.log("mids: ", mids);
       messagesAdapter.upsertMany(state, mids);
     },
     removeMessage: messagesAdapter.removeOne,

--- a/src/store/Messages.js
+++ b/src/store/Messages.js
@@ -27,9 +27,12 @@ export const messages = createSlice({
     upsertMessage: messagesAdapter.upsertOne,
     upsertMessages: messagesAdapter.upsertMany,
     markMessagesAsRead: (state, action) => {
-      const mids = action.payload.map((id) => {
-        return { _id: id, status: "read" };
-      });
+      const mids = action.payload
+        .filter((id) => !!state.entities[id])
+        .map((id) => {
+          return { _id: id, status: "read" };
+        });
+      console.log("mids: ", mids);
       messagesAdapter.upsertMany(state, mids);
     },
     removeMessage: messagesAdapter.removeOne,


### PR DESCRIPTION
* fixed duplicate Media objects in chat when you are scrolling at first time after create it
* delete fantom messages on receipt of `message_read`, until current messages are received
* when receiving pictures, unnecessary addition of the text "Photo\Photos" to the `body` field has been removed 